### PR TITLE
Move net-istio to its own folder for consistency.

### DIFF
--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -43,7 +43,7 @@ jobs:
           directory: ./third_party/contour-latest
           files: net-contour.yaml contour.yaml
         - nightly: net-istio
-          directory: ./third_party/
+          directory: ./third_party/istio-latest
           files: net-istio.yaml
         - nightly: net-kourier
           directory: ./third_party/kourier-latest


### PR DESCRIPTION
In conjunction with https://github.com/knative/serving/pull/10028.