### PR TITLE
Remove tektoncd repos from receiving automated PRs

### DIFF
--- a/actions-exclude.yaml
+++ b/actions-exclude.yaml
@@ -1,5 +1,2 @@
 # Haven't asked if they want them.
 - "google/exposure-notifications-server"
-# Tekton doesn't want actions
-- "tektoncd/pipeline"
-- "tektoncd/triggers"

--- a/deps-exclude.yaml
+++ b/deps-exclude.yaml
@@ -1,3 +1,2 @@
 # Don't have ./hack/update-deps.sh --upgrade
 - "google/exposure-notifications-server"
-- "tektoncd/triggers"

--- a/prettier-exclude.yaml
+++ b/prettier-exclude.yaml
@@ -4,7 +4,5 @@
 - "knative/client"
 # Haven't asked if they want them.
 - "google/exposure-notifications-server"
-# Tekton has unresolved issues
-- "tektoncd/pipeline"
 # Generated docs have problems
 - "google/go-containerregistry"

--- a/repos.yaml
+++ b/repos.yaml
@@ -160,18 +160,6 @@
   channel: 'net-certmanager'
   assignees: knative-sandbox/networking-wg-leads
 
-# tektoncd
-- name: 'tektoncd/pipeline'
-  meta-organization: 'knative' # Pull actions from the Knative org.
-  fork: 'knative-automation/pipeline'
-  channel: '@vdemeester'
-  assignees: tektoncd/core-maintainers
-- name: 'tektoncd/triggers'
-  meta-organization: 'knative' # Pull actions from the Knative org.
-  fork: 'knative-automation/triggers'
-  channel: '@ImJasonH'
-  assignees: tektoncd/core-maintainers
-
 # google
 - name: 'google/exposure-notifications-server'
   meta-organization: 'knative' # Pull actions from the Knative org.


### PR DESCRIPTION
The knative-automation account doesn't pass the EasyCLA check.

/kind removal
