### PR TITLE
Fix and simplify branch defaulting behavior

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -22,8 +22,6 @@ on:
     inputs:
       branch:
         description: 'Branch Name? (empty for default branch of the respective repository)'
-        required: true
-        default: ''
 
       release:
         description: 'Release? (vX.Y) defaults to current release'
@@ -51,7 +49,6 @@ jobs:
       misspell-names: ${{ steps.load-matrix.outputs.misspell-names }}
       prettier-include: ${{ steps.load-matrix.outputs.prettier-include }}
       prettier-names: ${{ steps.load-matrix.outputs.prettier-names }}
-      branch: ${{ steps.load-matrix.outputs.branch }}
       release: ${{ steps.load-matrix.outputs.release }}
       reason: ${{ steps.load-matrix.outputs.reason }}
     steps:
@@ -98,9 +95,6 @@ jobs:
           fi
         done
 
-        # Create a properly default property for downstream.
-        echo "::set-output name=branch::${{ github.event.inputs.branch }}"
-
         # If manual trigger sent release.
         if [[ "${{ github.event.inputs.release }}" != "" ]]; then
           echo "::set-output name=release::${{ github.event.inputs.release }}"
@@ -141,11 +135,12 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ${{ matrix.name }}
-        ref: ${{ needs.meta.outputs.branch }}
+        ref: ${{ github.event.inputs.branch }}
 
     # This is required because the branch setting might be empty (to infer a default), so
     # after checkout we fetch what the checkout action decided to check out.
     - name: Infer branch from checkout
+      id: inferbranch
       run: |
         echo "::set-output name=branch::$(git branch --show-current)"
 
@@ -227,7 +222,7 @@ jobs:
 
         # Where to stage the change.
         push-to-fork: ${{ matrix.fork }}
-        branch: auto-updates/update-deps-${{ needs.meta.outputs.branch }}
+        branch: auto-updates/update-deps-${{ steps.inferbranch.outputs.branch }}
         signoff: true
         delete-branch: true
 
@@ -237,7 +232,7 @@ jobs:
 
           ${{ steps.updatedeps.outputs.deplog }}
 
-        title: '[${{ needs.meta.outputs.branch }}] Upgrade to latest dependencies'
+        title: '[${{ steps.inferbranch.outputs.branch }}] Upgrade to latest dependencies'
         body: |
           ${{ needs.meta.outputs.reason }} -${{ github.actor }}
 
@@ -266,7 +261,7 @@ jobs:
         SLACK_CHANNEL: ${{ matrix.channel }}
         SLACK_COLOR: '#8E1600'
         MSG_MINIMAL: 'true'
-        SLACK_TITLE: "[${{ needs.meta.outputs.branch }}] Updating dependencies for ${{ matrix.name }} failed."
+        SLACK_TITLE: "[${{ steps.inferbranch.outputs.branch }}] Updating dependencies for ${{ matrix.name }} failed."
         SLACK_MESSAGE: |
           For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ${{ needs.meta.outputs.reason }} -${{ github.actor }}


### PR DESCRIPTION
As per title, this fixes the branch behavior of the action and simplifies it a bit too.

The issue before was that the `set-output` call was on the wrong scope, so this changes that. The `required` attribute needs to go too to be able to run this against main/master manually. Finally, the top-level branch prop is now unused, so dropping that.

/assign @mattmoor 