### PR TITLE
Don't notify #ggcr or #ko Slack channels

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -182,12 +182,10 @@
 - name: 'google/go-containerregistry'
   meta-organization: 'knative' # Pull actions from the Knative org.
   fork: 'knative-automation/go-containerregistry'
-  channel: 'ggcr'
   assignees: '@jonjohnsonjr @ImJasonH @mattmoor'
 - name: 'google/ko'
   meta-organization: 'knative' # Pull actions from the Knative org.
   fork: 'knative-automation/ko'
-  channel: 'ko'
   assignees: '@jonjohnsonjr @ImJasonH @mattmoor'
 
 # vmware-tanzu


### PR DESCRIPTION
Repo maintainers already get notified by being assigned.

/kind removal

**Release Note**

```release-note
NONE
```

/assign @mattmoor 