### PR TITLE
Exclude go-containerregistry from actions sync

### DIFF
--- a/actions-exclude.yaml
+++ b/actions-exclude.yaml
@@ -1,2 +1,5 @@
 # Haven't asked if they want them.
 - "google/exposure-notifications-server"
+
+# Opted out.
+- "google/go-containerregistry"


### PR DESCRIPTION
cc @jonjohnsonjr

ggcr runs a different matrix of Go versions since https://github.com/google/go-containerregistry/pull/945, and we'd like to avoid PRs like https://github.com/google/go-containerregistry/pull/947