### PR TITLE
Switch knobots to 0.22 for next release

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -36,7 +36,7 @@ jobs:
     env:
       #########################################
       #   Update this section each release.   #
-      RELEASE: 'v0.21'
+      RELEASE: 'v0.22'
       #########################################
     outputs:
       actions-include: ${{ steps.load-matrix.outputs.actions-include }}


### PR DESCRIPTION
/assign @n3wscott @lionelvillard @markusthoemmes @evankanderson 

/hold

I'm putting a HOLD on this because docs and operator have not yet cut and merging this will start to float PKG forward, which we don't want.