### PR TITLE
Fix go get in auto-fork action

### DIFF
--- a/.github/workflows/auto-fork.yaml
+++ b/.github/workflows/auto-fork.yaml
@@ -40,7 +40,7 @@ jobs:
         go-version: 1.15.x
 
     - name: Install Dependencies
-      run: go get knative.dev/test-infra/buoy@master
+      run: GO111MODULE=on go get knative.dev/test-infra/buoy@master
 
     - name: Install gh
       run: |


### PR DESCRIPTION
This PR should fix the following error in `auto-fork` action.

https://github.com/knative-sandbox/knobots/runs/1986629761?check_suite_focus=true

```bash
Run go get knative.dev/test-infra/buoy@master
  go get knative.dev/test-infra/buoy@master
  shell: /bin/bash -e {0}
  env:
    GOROOT: /opt/hostedtoolcache/go/1.15.8/x64
go: cannot use path@version syntax in GOPATH mode
Error: Process completed with exit code 1.
```


# Changes

- :bug: Fix go get in auto-fork action

/kind bug

/cc @n3wscott 