### PR TITLE
Allow opt-out of syncing certain actions

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -479,7 +479,7 @@ jobs:
         cp $(find "${GITHUB_WORKSPACE}/meta/workflow-templates" -type f -name '*.yaml') \
           "${GITHUB_WORKSPACE}/main/.github/workflows/"
         yaml2json < "${GITHUB_WORKSPACE}/meta/actions-omitted.yaml" | \
-          jq -r ".[\"${{ matrix.meta-organization }}/${{ matrix.name }}\"].omit | .[] | \"*\"" | \
+          jq -r "(.[\"${{ matrix.meta-organization }}/${{ matrix.name }}\"] // {\"omit\": []}).omit[] + \"*\"" | \
           while read GLOB; do rm "${GITHUB_WORKSPACE}/main/.github/workflows/${GLOB}"; done
 
     - name: Create Pull Request

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -478,6 +478,9 @@ jobs:
         mkdir -p "${GITHUB_WORKSPACE}/main/.github/workflows/"
         cp $(find "${GITHUB_WORKSPACE}/meta/workflow-templates" -type f -name '*.yaml') \
           "${GITHUB_WORKSPACE}/main/.github/workflows/"
+        yaml2json < "${GITHUB_WORKSPACE}/meta/actions-omitted.yaml" | \
+          jq -r ".[\"${{ matrix.meta-organization }}/${{ matrix.name }}\"].omit | .[] | \"*\"" | \
+          while read GLOB; do rm "${GITHUB_WORKSPACE}/main/.github/workflows/${GLOB}"; done
 
     - name: Create Pull Request
       id: cpr

--- a/actions-omitted.yaml
+++ b/actions-omitted.yaml
@@ -1,0 +1,7 @@
+# Avoid syncing certain actions to certain repos. (For example, go testing from non-go repos.)
+# This uses a glob prefix match (adds * to the end of each omit), so no need to specify '.yaml'
+'knative/website':
+    omit:
+    - 'knative-go-'
+    - 'knative-releasability'
+    - 'knative-release-notes'


### PR DESCRIPTION
Right now, `action-sync` syncs all the actions into every repo. But not all actions
apply to all repos (for example, `go build` probably shouldn't apply to `website`, `docs`,
or `community`).

Adds an opt-out mechanism which removes unwanted actions files before creating the PR.

I'm not sure how to test this easily.
