### PR TITLE
Add the knobots repo for configuration

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -460,17 +460,22 @@ jobs:
 
     steps:
 
-    - name: Check out code onto GOPATH
+    - name: Check out target repo
       uses: actions/checkout@v2
       with:
         path: main
         repository: ${{ matrix.name }}
 
-    - name: Check out code onto GOPATH
+    - name: Check out source templates
       uses: actions/checkout@v2
       with:
         path: meta
         repository: "${{ matrix.meta-organization }}/.github"
+
+    - name: Check out knobots configuration
+      uses: actions/checkout@v2
+      with:
+        path: config
 
     - name: Copy Actions
       shell: bash
@@ -478,7 +483,7 @@ jobs:
         mkdir -p "${GITHUB_WORKSPACE}/main/.github/workflows/"
         cp $(find "${GITHUB_WORKSPACE}/meta/workflow-templates" -type f -name '*.yaml') \
           "${GITHUB_WORKSPACE}/main/.github/workflows/"
-        yaml2json < "${GITHUB_WORKSPACE}/meta/actions-omitted.yaml" | \
+        yaml2json < "${GITHUB_WORKSPACE}/config/actions-omitted.yaml" | \
           jq -r "(.[\"${{ matrix.meta-organization }}/${{ matrix.name }}\"] // {\"omit\": []}).omit[] + \"*\"" | \
           while read GLOB; do rm "${GITHUB_WORKSPACE}/main/.github/workflows/${GLOB}"; done
 


### PR DESCRIPTION
Fixes e.g. https://github.com/knative-sandbox/knobots/runs/2162366471?check_suite_focus=true

```
 mkdir -p "${GITHUB_WORKSPACE}/main/.github/workflows/"
  cp $(find "${GITHUB_WORKSPACE}/meta/workflow-templates" -type f -name '*.yaml') \
    "${GITHUB_WORKSPACE}/main/.github/workflows/"
  yaml2json < "${GITHUB_WORKSPACE}/meta/actions-omitted.yaml" | \
    jq -r "(.[\"knative-sandbox/knative-sandbox/reconciler-test\"] // {\"omit\": []}).omit[] + \"*\"" | \
    while read GLOB; do rm "${GITHUB_WORKSPACE}/main/.github/workflows/${GLOB}"; done
/home/runner/work/_temp/5ca7e53d-ddcd-4458-a74b-b09ac4061add.sh: line 4: /home/runner/work/knobots/knobots/meta/actions-omitted.yaml: No such file or directory
Error: Process completed with exit code 1.
```

It turns out that the `actions-omitted.yaml` file is in the *knobots* repo, not the `.github` repo or the target repo.
