### PR TITLE
Load yaml2json before calling it

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -487,7 +487,7 @@ jobs:
       run: |
         go get github.com/bronze1man/yaml2json
 
-mkdir -p "${GITHUB_WORKSPACE}/main/.github/workflows/"
+        mkdir -p "${GITHUB_WORKSPACE}/main/.github/workflows/"
         cp $(find "${GITHUB_WORKSPACE}/meta/workflow-templates" -type f -name '*.yaml') \
           "${GITHUB_WORKSPACE}/main/.github/workflows/"
         yaml2json < "${GITHUB_WORKSPACE}/config/actions-omitted.yaml" | \

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -477,10 +477,17 @@ jobs:
       with:
         path: config
 
+    - name: Set up Go 1.15.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15.x
+
     - name: Copy Actions
       shell: bash
       run: |
-        mkdir -p "${GITHUB_WORKSPACE}/main/.github/workflows/"
+        go get github.com/bronze1man/yaml2json
+
+mkdir -p "${GITHUB_WORKSPACE}/main/.github/workflows/"
         cp $(find "${GITHUB_WORKSPACE}/meta/workflow-templates" -type f -name '*.yaml') \
           "${GITHUB_WORKSPACE}/main/.github/workflows/"
         yaml2json < "${GITHUB_WORKSPACE}/config/actions-omitted.yaml" | \


### PR DESCRIPTION
Fixes https://github.com/knative-sandbox/knobots/runs/2170334340?check_suite_focus=true

```
  mkdir -p "${GITHUB_WORKSPACE}/main/.github/workflows/"
  cp $(find "${GITHUB_WORKSPACE}/meta/workflow-templates" -type f -name '*.yaml') \
    "${GITHUB_WORKSPACE}/main/.github/workflows/"
  yaml2json < "${GITHUB_WORKSPACE}/config/actions-omitted.yaml" | \
    jq -r "(.[\"knative/knative/caching\"] // {\"omit\": []}).omit[] + \"*\"" | \
    while read GLOB; do rm "${GITHUB_WORKSPACE}/main/.github/workflows/${GLOB}"; done
/home/runner/work/_temp/60170734-7668-498a-9d40-be001d128480.sh: line 4: yaml2json: command not found
Error: Process completed with exit code 127.
```

I wish I knew a better way to test this, sorry for all the spam!
