### PR TITLE
Fix repo path in update-community action

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -597,7 +597,7 @@ jobs:
         branch: auto-updates/common-aliases
         signoff: true
         delete-branch: true
-        path: matrix.name
+        path: main
 
         commit-message: 'Update knative/community files'
         title: '[Automated] Update knative/community files'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

This PR should fix the following error:
https://github.com/knative-sandbox/knobots/runs/2198328771?check_suite_focus=true#step:6:10

PR target path should be the same as checkout one.

```
    - name: Check out code onto GOPATH
      uses: actions/checkout@v2
      with:
        path: main
        repository: ${{ matrix.name }}
```

# Changes

- :bug: Fix repo path in update-community action that is used to create PR


/cc @evankanderson 
