### PR TITLE
Add net-ingressv2 to the repo list

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -178,6 +178,11 @@
   fork: 'knative-automation/net-certmanager'
   channel: 'net-certmanager'
   assignees: knative-sandbox/networking-wg-leads
+- name: 'knative-sandbox/net-ingressv2'
+  meta-organization: 'knative-sandbox'
+  fork: 'knative-automation/net-ingressv2'
+  channel: 'net-ingressv2'
+  assignees: knative-sandbox/networking-wg-leads
 
 # knative-sandbox (kperf)
 - name: 'knative-sandbox/kperf'


### PR DESCRIPTION
As per title, this patch adds net-ingressv2 to the repo list
to kick auto deps update.

/cc @ZhiminXiang @tcnghia @markusthoemmes 
