### PR TITLE
Fix #69 syntax errors, simplify

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -32,6 +32,7 @@ on:
 
       pr-empty-deps:
         description: "If true, send update PRs even for deps changes that don't change vendor. Use this only for releases."
+        default: false
 
 jobs:
   meta:

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -32,7 +32,7 @@ on:
 
       pr-empty-deps:
         description: "If true, send update PRs even for deps changes that don't change vendor. Use this only for releases."
-        default: false
+        default: 'false'
 
 jobs:
   meta:

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -21,17 +21,17 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch Name? (empty for default branch of the respective repository)'
+        description: "Branch Name? (empty for default branch of the respective repository)"
 
       release:
-        description: 'Release? (vX.Y) defaults to current release'
+        description: "Release? (vX.Y) defaults to current release"
 
       reason:
-        description: 'Justification?'
+        description: "Justification?"
         required: true
 
-      pr_empty_deps:
-        description: 'If true, send update PRs even for deps changes that don't change vendor. Use this only for releases.'
+      pr-empty-deps:
+        description: "If true, send update PRs even for deps changes that don't change vendor. Use this only for releases."
 
 jobs:
   meta:
@@ -56,7 +56,6 @@ jobs:
       prettier-names: ${{ steps.load-matrix.outputs.prettier-names }}
       release: ${{ steps.load-matrix.outputs.release }}
       reason: ${{ steps.load-matrix.outputs.reason }}
-      pr_empty_deps: ${{ steps.load-matrix.outputs.pr_empty_deps }}
     steps:
     - name: Check out code onto GOPATH
       uses: actions/checkout@v2
@@ -114,8 +113,6 @@ jobs:
         else
           echo "::set-output name=reason::Cron."
         fi
-
-        echo "::set-output ${{ github.events.inputs.pr_empty_deps }}"
 
   update-deps:
     name: Update Deps and Codegen
@@ -197,7 +194,7 @@ jobs:
         # If we don't run this before the "git diff-index" it seems to list
         # every file that's been touched by codegen.
         git status
-        echo "create_pr=${{ needs.meta.outputs.pr_empty_deps }}" >> $GITHUB_ENV
+        echo "create_pr=${{ github.events.inputs.pr-empty-deps }}" >> $GITHUB_ENV
         for x in $(git diff-index --name-only HEAD --); do
           if [ "$(basename $x)" = "go.mod" ]; then
             continue


### PR DESCRIPTION
GitHub complained about an error on line 33:

https://github.com/knative-sandbox/knobots/actions/runs/723948091/workflow

Also discovered that `inputs` are stringly-typed, so defaulted the value to "false", rather than "".

Also fixed a mix of single-quotes and apostrophe on line 34.
