### PR TITLE
Bump release family to 0.23 after 0.22 release

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -36,7 +36,7 @@ jobs:
     env:
       #########################################
       #   Update this section each release.   #
-      RELEASE: 'v0.22'
+      RELEASE: 'v0.23'
       #########################################
     outputs:
       actions-include: ${{ steps.load-matrix.outputs.actions-include }}


### PR DESCRIPTION
As described in https://github.com/knative/release#after-the-release