### PR TITLE
enable verbose logging temporarily for nightly release bump job

### DIFF
--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -103,6 +103,7 @@ jobs:
       shell: bash
       id: nightlies
       run: |
+        set -x
         for x in ${{ matrix.files }}; do
           curl https://storage.googleapis.com/knative-nightly/${{ matrix.bucket }}/latest/$x > ${GITHUB_WORKSPACE}/${{ matrix.directory }}/$x
         done


### PR DESCRIPTION
`net-istio.yaml` in `knative/serving` hasn't been updated in a week and it's not clear why the job is skipping 


I get a diff of 
```diff
- serving.knative.dev/release: "v20210402-153a3ca3"
+ serving.knative.dev/release: "v20210410-018e5a89"
```