### PR TITLE
drop verbose logging and add some pipefail guards

### DIFF
--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -103,13 +103,13 @@ jobs:
       shell: bash
       id: nightlies
       run: |
-        set -x
         for x in ${{ matrix.files }}; do
           curl https://storage.googleapis.com/knative-nightly/${{ matrix.bucket }}/latest/$x > ${GITHUB_WORKSPACE}/${{ matrix.directory }}/$x
         done
 
         function release_labels() {
-          git diff | grep 'knative.dev/release' | tr -s ' '
+          # If grep matches no lines (exit code == 1) make this a noop since pipefail is on
+          git diff | { grep 'knative.dev/release' || [[ $? == 1 ]]; } | tr -s ' '
         }
 
         # Prior to the 'sed' we have output in the following format:
@@ -119,7 +119,9 @@ jobs:
         #
         ref_count=$(release_labels | sed 's/.* "\(.*\)"$/\1/' | cut -d '-' -f2 | sort -u | wc -l)
 
-        if [[ "$ref_count" -eq 1 ]]; then
+        if [[ "$ref_count" -lt 2 ]]; then
+          # For debugging
+          release_labels | sort -u
           echo "::warning file=.github.js,line=1::${{matrix.nightly}} -  skipping bump no changes"
           exit 0
         fi


### PR DESCRIPTION
istio nightly wasn't bumped because the nightly jobs failed - so undoing `set -x` 

I also noticed the script exited when `grep` returned no results - which can happen if a release is re-generated and there is a whitespace difference in the yamls 🤷‍♂️ 