### PR TITLE
Add jq command to update-actions

### DIFF
--- a/actions/update-actions/Dockerfile
+++ b/actions/update-actions/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM golang
 
-RUN go get github.com/bronze1man/yaml2json
+RUN go get github.com/bronze1man/yaml2json && apt-get update && apt-get install -y jq
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
`actions/update-actions/entrypoint.sh` uses jq command but the container does not install jq.
So it always produces the following error:

e.g. https://github.com/knative-sandbox/knobots/runs/2514621145?check_suite_focus=true (please check in `Apply work`)

```
/entrypoint.sh: line 27: jq: command not found
```

This patch fixes it.

/cc @evankanderson @xtreme-sameer-vohra @n3wscott 