### PR TITLE
Remove unnecessary `$` in update actions

### DIFF
--- a/cmd/gen-actions/actions_template.yaml
+++ b/cmd/gen-actions/actions_template.yaml
@@ -117,7 +117,7 @@ jobs:
           {{github `github.event.inputs.reason || 'Cron'`}} -{{github "github.actor"}}
 
           /cc {{github "matrix.assignees"}}
-          /assign ${{github "matrix.assignees"}}
+          /assign {{github "matrix.assignees"}}
 
           Produced by: {{github "github.repository"}}/actions/{{.Action}}
 


### PR DESCRIPTION
This patch makes a tiny change which removes unnecessary `$`.

For example please refer to https://github.com/knative-sandbox/net-contour/pull/493.
It has `$` in the `/assign` line.

```
/assign $knative-sandbox/networking-wg-leads
```

/cc @evankanderson @n3wscott @markusthoemmes 