### PR TITLE
Remove extra `$` in all template

### DIFF
--- a/.github/workflows/auto-update-actions.yaml
+++ b/.github/workflows/auto-update-actions.yaml
@@ -124,7 +124,7 @@ jobs:
           ${{ github.event.inputs.reason || 'Cron' }} -${{ github.actor }}
 
           /cc ${{ matrix.assignees }}
-          /assign $${{ matrix.assignees }}
+          /assign ${{ matrix.assignees }}
 
           Produced by: ${{ github.repository }}/actions/update-actions
 

--- a/.github/workflows/auto-update-community.yaml
+++ b/.github/workflows/auto-update-community.yaml
@@ -124,7 +124,7 @@ jobs:
           ${{ github.event.inputs.reason || 'Cron' }} -${{ github.actor }}
 
           /cc ${{ matrix.assignees }}
-          /assign $${{ matrix.assignees }}
+          /assign ${{ matrix.assignees }}
 
           Produced by: ${{ github.repository }}/actions/update-community
 

--- a/.github/workflows/auto-update-deps.yaml
+++ b/.github/workflows/auto-update-deps.yaml
@@ -129,7 +129,7 @@ jobs:
           ${{ github.event.inputs.reason || 'Cron' }} -${{ github.actor }}
 
           /cc ${{ matrix.assignees }}
-          /assign $${{ matrix.assignees }}
+          /assign ${{ matrix.assignees }}
 
           Produced by: ${{ github.repository }}/actions/update-deps
 

--- a/.github/workflows/auto-update-gofmt.yaml
+++ b/.github/workflows/auto-update-gofmt.yaml
@@ -118,7 +118,7 @@ jobs:
           ${{ github.event.inputs.reason || 'Cron' }} -${{ github.actor }}
 
           /cc ${{ matrix.assignees }}
-          /assign $${{ matrix.assignees }}
+          /assign ${{ matrix.assignees }}
 
           Produced by: ${{ github.repository }}/actions/update-gofmt
 

--- a/.github/workflows/auto-update-markdown.yaml
+++ b/.github/workflows/auto-update-markdown.yaml
@@ -118,7 +118,7 @@ jobs:
           ${{ github.event.inputs.reason || 'Cron' }} -${{ github.actor }}
 
           /cc ${{ matrix.assignees }}
-          /assign $${{ matrix.assignees }}
+          /assign ${{ matrix.assignees }}
 
           Produced by: ${{ github.repository }}/actions/update-markdown
 

--- a/.github/workflows/auto-update-misspell.yaml
+++ b/.github/workflows/auto-update-misspell.yaml
@@ -118,7 +118,7 @@ jobs:
           ${{ github.event.inputs.reason || 'Cron' }} -${{ github.actor }}
 
           /cc ${{ matrix.assignees }}
-          /assign $${{ matrix.assignees }}
+          /assign ${{ matrix.assignees }}
 
           Produced by: ${{ github.repository }}/actions/update-misspell
 


### PR DESCRIPTION
This is same fix with https://github.com/knative-sandbox/knobots/pull/84

All template has the issue as https://github.com/knative/serving/pull/11338#issue-643804896

```
/assign $knative/serving-writers
```
/cc @evankanderson @n3wscott @markusthoemmes

