### PR TITLE
Align Go version with 1.16

### DIFF
--- a/.github/workflows/auto-fork.yaml
+++ b/.github/workflows/auto-fork.yaml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
 
-    - name: Set up Go 1.15
+    - name: Set up Go 1.16
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.x
+        go-version: 1.16.x
 
     - name: Install Dependencies
       run: GO111MODULE=on go get knative.dev/test-infra/buoy@master

--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -84,10 +84,10 @@ jobs:
           assignee: "@knative/delivery-wg-leads"
 
     steps:
-    - name: Set up Go 1.15.x
+    - name: Set up Go 1.16.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.x
+        go-version: 1.16.x
 
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
This patch aligns Go version with 1.16 in the workflows.
All repos are using Go 1.16 now.
