### PR TITLE
Add client's homebrew repositories

### DIFF
--- a/actions-exclude.yaml
+++ b/actions-exclude.yaml
@@ -1,1 +1,3 @@
 - "knative/release"
+- "knative/homebrew-client"
+- "knative-sandbox/homebrew-kn-plugins"

--- a/deps-exclude.yaml
+++ b/deps-exclude.yaml
@@ -1,1 +1,3 @@
 - "knative/release"
+- "knative/homebrew-client"
+- "knative-sandbox/homebrew-kn-plugins"

--- a/gotool-exclude.yaml
+++ b/gotool-exclude.yaml
@@ -1,1 +1,3 @@
 - "knative/release"
+- "knative/homebrew-client"
+- "knative-sandbox/homebrew-kn-plugins"

--- a/repos.yaml
+++ b/repos.yaml
@@ -51,6 +51,11 @@
   fork: 'knative-automation/client'
   channel: 'cli'
   assignees: knative/client-wg-leads
+- name: 'knative/homebrew-client'
+  meta-organization: 'knative'
+  fork: 'knative-automation/homebrew-client'
+  channel: 'cli'
+  assignees: knative/client-wg-leads
 - name: 'knative/release'
   meta-organization: 'knative'
   fork: 'knative-automation/release'
@@ -197,6 +202,12 @@
   assignees: knative/productivity-wg-leads
 
 # knative-sandbox/kn-plugin-*, sorted alphabetically
+- name: 'knative-sandbox/homebrew-kn-plugins'
+  meta-organization: 'knative-sandbox'
+  fork: 'knative-automation/homebrew-kn-plugins'
+  channel: 'cli'
+  assignees: 'knative-sandbox/client-writers'
+  
 - name: 'knative-sandbox/kn-plugin-admin'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/kn-plugin-admin'


### PR DESCRIPTION
Since we included the Homebrew repositories in the release process. We should keep at least `OWNERS` file up-to-date, e.g to have current release leads, or WG leads present.

# Changes

- Add repo `knative/homebrew-client`
- Add repo `knative-sanbox/homebrew-kn-plugins`
- Enable only meaningful actions for the repositories 

/cc @rhuss 
