### PR TITLE
Fix Eventing nightly updates for eventing-kafka-broker

### DIFF
--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -33,7 +33,8 @@ jobs:
         - net-contour
         - net-istio
         - net-kourier
-        - eventing-kafka-broker
+        - eventing-kafka-broker-eventing-kafka
+        - eventing-kafka-broker-eventing
 
         # Map to nightly-specific parameters.
         include:
@@ -73,7 +74,7 @@ jobs:
           fork: serving
           channel: net-kourier
           assignee: "@knative/networking-wg-leads"
-        - nightly: eventing-kafka-broker
+        - nightly: eventing-kafka-broker-eventing
           module: knative.dev/eventing-kafka-broker
           directory: ./third_party/eventing-latest
           files: eventing-crds.yaml eventing-core.yaml
@@ -82,7 +83,7 @@ jobs:
           fork: eventing-kafka-broker
           channel: eventing-delivery
           assignee: "@knative/delivery-wg-leads"
-        - nightly: eventing-kafka-broker
+        - nightly: eventing-kafka-broker-eventing-kafka
           module: knative.dev/eventing-kafka-broker
           directory: ./third_party/eventing-kafka-latest
           files: channel-crds.yaml


### PR DESCRIPTION
# Changes

We're not receiving nightly updates for eventing since 12 days ago https://github.com/knative-sandbox/eventing-kafka-broker/tree/main/third_party/eventing-latest

The `eventing-kafka-broker` nightly job was mapped to 2 includes, so GH actions was using only the last one.

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Fix eventing nightly updates for eventing-kafka-broker

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->