### PR TITLE
Disable kn-plugin-func dependencies

### DIFF
--- a/deps-exclude.yaml
+++ b/deps-exclude.yaml
@@ -1,3 +1,4 @@
 - "knative/release"
 - "knative/homebrew-client"
 - "knative-sandbox/homebrew-kn-plugins"
+- "knative-sandbox/kn-plugin-func"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

As per title. The respective infra is not there yet and we'll have to figure out the best way to release an interim release to be able to catch up with Knative HEAD and get onto the Knative release-train.

/assign @dsimansk 