### PR TITLE
Revert "adding COC doc for all knative repos (#112)"

### DIFF
--- a/actions/update-community/entrypoint.sh
+++ b/actions/update-community/entrypoint.sh
@@ -31,17 +31,7 @@ if [ -f "${GITHUB_WORKSPACE}/meta/${FILE}" ]; then
 else
   echo "Could not find ${FILE}, skipping"
 fi
-
-FILE="CODE-OF-CONDUCT.md"
-if [ -f "${GITHUB_WORKSPACE}/meta/${FILE}" ]; then
-  cp "${GITHUB_WORKSPACE}/meta/${FILE}" "${GITHUB_WORKSPACE}/main/CODE-OF-CONDUCT.md"
-  echo "Copying ${GITHUB_WORKSPACE}/meta/${FILE} -> ${GITHUB_WORKSPACE}/main/CODE-OF-CONDUCT.md"
-  create_pr="true"
-else
-  echo "Could not find ${FILE}, skipping"
-fi
-
-# TODO: copy other files over, like CONTRUBUTING.md or LICENSE
+# TODO: copy other files over, like CODE-OF-CONDUCT.md
 
 # Ensure files have the same owner as the checkout directory.
 # See https://github.com/knative-sandbox/knobots/issues/79


### PR DESCRIPTION
This reverts commit f723a9004cbd85cb4585ba303004faae28c11104.

Per the discussion [here](https://github.com/knative/serving/pull/12057#discussion_r718279987), the COC doc in community is not necessarily suitable for all repos, so this PR takes it back out of the automation.

cc @markusthoemmes  @evankanderson 