### PR TITLE
Move all update actions to 1.17

### DIFF
--- a/actions/calculate-matrix/Dockerfile
+++ b/actions/calculate-matrix/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # TODO: figure out how to template this.
-FROM golang:1.16
+FROM golang:1.17
 
 RUN go get github.com/bronze1man/yaml2json && apt-get update && apt-get install -y jq
 

--- a/actions/update-deps/Dockerfile
+++ b/actions/update-deps/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # TODO: figure out how to template this.
-FROM golang:1.16
+FROM golang:1.17
 
 RUN go get github.com/google/ko@v0.6.0 github.com/google/licenseclassifier github.com/google/go-licenses github.com/dprotaso/modlog knative.dev/test-infra/buoy
 

--- a/actions/update-gofmt/Dockerfile
+++ b/actions/update-gofmt/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # TODO: figure out how to template this.
-FROM golang:1.16
+FROM golang:1.17
 
 RUN go get golang.org/x/tools/cmd/goimports
 

--- a/actions/update-misspell/Dockerfile
+++ b/actions/update-misspell/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # TODO: figure out how to template this.
-FROM golang:1.16
+FROM golang:1.17
 
 RUN go get github.com/client9/misspell/cmd/misspell
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

We need the dep updates to be 1.17 based too, as well as the gofmt action. Might as well make them all 1.17.