### PR TITLE
Run releasability for quickstart

### DIFF
--- a/actions-omitted.yaml
+++ b/actions-omitted.yaml
@@ -3,9 +3,6 @@
 knative-sandbox/kn-plugin-diag:
   omit:
     - knative-releasability
-knative-sandbox/kn-plugin-quickstart:
-  omit:
-    - knative-releasability
 knative-sandbox/kperf:
   omit:
     - knative-releasability


### PR DESCRIPTION
# Changes

As quickstart plugin is now on the release train, run the releasability job for it.

