### PR TITLE
Remove website repo from automation

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -41,11 +41,6 @@
   fork: 'knative-automation/docs'
   channel: 'docs'
   assignees: knative/serving-writers knative/eventing-writers knative/docs-wg-leads
-- name: 'knative/website'
-  meta-organization: 'knative'
-  fork: 'knative-automation/website'
-  channel: 'docs'
-  assignees: knative-docs/docs-wg-leads
 - name: 'knative/client'
   meta-organization: 'knative'
   fork: 'knative-automation/client'


### PR DESCRIPTION
# Changes

The website repo has been archived, so let's remove it from the automation...

<img width="826" alt="image" src="https://user-images.githubusercontent.com/44698588/146106764-835bbd0f-d388-4131-ae1c-df4cc551cd79.png">

