### PR TITLE
fix grep expression when figuring out release shas

### DIFF
--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -114,15 +114,14 @@ jobs:
           assignee: "@knative-sandbox/eventing-rabbitmq-approvers"
 
     steps:
-    - name: Set up Go 1.16.x
+    - name: Set up Go 1.17.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.x
+        go-version: 1.17.x
 
     - name: Install Dependencies
       run: |
-        cd $(mktemp -d)
-        go get github.com/dprotaso/modlog
+        go install github.com/dprotaso/modlog@latest
 
     - name: Check out code onto GOPATH
       uses: actions/checkout@v2
@@ -139,7 +138,7 @@ jobs:
 
         function release_labels() {
           # If grep matches no lines (exit code == 1) make this a noop since pipefail is on
-          git diff | { grep 'knative.dev/release' || [[ $? == 1 ]]; } | tr -s ' '
+          git diff | { grep -E 'knative.dev/release.?:' || [[ $? == 1 ]]; } | tr -s ' '
         }
 
         # Prior to the 'sed' we have output in the following format:


### PR DESCRIPTION
The special release label was being used in a webhook selector which was
removed. This diff broke how we calculated the from and to sha's for the
nightly updates

ie. the following diff is what broke the script before

```
-    serving.knative.dev/release: "v20220203-d2a7c418"
+    serving.knative.dev/release: "v20220217-f40f6752"
-    serving.knative.dev/release: "v20220203-d2a7c418"
+    serving.knative.dev/release: "v20220217-f40f6752"
-        - key: serving.knative.dev/release
```

/assign @kvmware 