### PR TITLE
Replace channel-wg-leads and source-wg-leads by eventing-writers

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -91,83 +91,83 @@
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/sample-source'
   channel: 'eventing-sources'
-  assignees: knative-sandbox/source-wg-leads lberk
+  assignees: knative-sandbox/eventing-writers lberk
 
 # knative-sandbox/control-protocol
 - name: 'knative-sandbox/control-protocol'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/control-protocol'
   channel: 'eventing-delivery'
-  assignees: knative-sandbox/channel-wg-leads
+  assignees: knative-sandbox/eventing-writers
 
 # knative-sandbox/discovery
 - name: 'knative-sandbox/discovery'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/discovery'
   channel: 'eventing-sources'
-  assignees: knative-sandbox/source-wg-leads
+  assignees: knative-sandbox/eventing-writers
 
 # knative-sandbox/eventing-* (eventing), sorted alphabetically
 - name: 'knative-sandbox/eventing-autoscaler-keda'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/eventing-autoscaler-keda'
   channel: 'eventing-delivery'
-  assignees: knative-sandbox/source-wg-leads
+  assignees: knative-sandbox/eventing-writers
 - name: 'knative-sandbox/eventing-awssqs'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/eventing-awssqs'
   channel: 'eventing-sources'
-  assignees: knative-sandbox/source-wg-leads
+  assignees: knative-sandbox/eventing-writers
 - name: 'knative-sandbox/eventing-ceph'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/eventing-ceph'
   channel: 'eventing-sources'
-  assignees: knative-sandbox/source-wg-leads
+  assignees: knative-sandbox/eventing-writers
 - name: 'knative-sandbox/eventing-couchdb'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/eventing-couchdb'
   channel: 'eventing-sources'
-  assignees: knative-sandbox/source-wg-leads
+  assignees: knative-sandbox/eventing-writers
 - name: 'knative-sandbox/eventing-github'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/eventing-github'
   channel: 'eventing-sources'
-  assignees: knative-sandbox/source-wg-leads
+  assignees: knative-sandbox/eventing-writers
 - name: 'knative-sandbox/eventing-gitlab'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/eventing-gitlab'
   channel: 'eventing-sources'
-  assignees: knative-sandbox/source-wg-leads
+  assignees: knative-sandbox/eventing-writers
 - name: 'knative-sandbox/eventing-kafka'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/eventing-kafka'
   channel: 'eventing-delivery'
-  assignees: knative-sandbox/channel-wg-leads
+  assignees: knative-sandbox/eventing-writers
 - name: 'knative-sandbox/eventing-kafka-broker'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/eventing-kafka-broker'
   channel: 'eventing-delivery'
-  assignees: knative-sandbox/channel-wg-leads
+  assignees: knative-sandbox/eventing-writers
 - name: 'knative-sandbox/eventing-kogito'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/eventing-kogito'
   channel: 'eventing-sources'
-  assignees: knative-sandbox/source-wg-leads
+  assignees: knative-sandbox/eventing-writers
 - name: 'knative-sandbox/eventing-natss'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/eventing-natss'
   channel: 'eventing-delivery'
-  assignees: knative-sandbox/channel-wg-leads
+  assignees: knative-sandbox/eventing-writers
 - name: 'knative-sandbox/eventing-rabbitmq'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/eventing-rabbitmq'
   channel: 'eventing-delivery'
-  assignees: knative-sandbox/channel-wg-leads
+  assignees: knative-sandbox/eventing-writers
 - name: 'knative-sandbox/eventing-redis'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/eventing-redis'
   channel: 'eventing-sources'
-  assignees: knative-sandbox/source-wg-leads
+  assignees: knative-sandbox/eventing-writers
 
 # knative-sandbox (networking)
 - name: 'knative-sandbox/net-contour'


### PR DESCRIPTION
Since both the Delivery and Sources WG don't exist anymore.
