### PR TITLE
bake next release version into workflow template

### DIFF
--- a/workflow-templates/knative-releasability.yaml
+++ b/workflow-templates/knative-releasability.yaml
@@ -14,12 +14,15 @@ on:
       releaseFamily:
         description: 'Release? (vX.Y)'
         required: false
+        default: 'v1.4'
       moduleReleaseFamily:
         description: 'Module Release? (vX.Y)'
         required: false
+        default: 'v0.31'
       slackChannel:
         description: 'Slack Channel? (release-#)'
         required: false
+        default: 'release-1dot4'
 
 jobs:
   releasability:


### PR DESCRIPTION
We moved the workflows that are propagated to all the repos into the `knobots` repo.

We want to bake in the release version in the respective repos - so this PR adds the version as the default.

/hold will discuss with the release leads