### PR TITLE
Enable auto-merge for update-community PRs and small cleanups

### DIFF
--- a/.github/workflows/auto-update-actions.yaml
+++ b/.github/workflows/auto-update-actions.yaml
@@ -111,6 +111,10 @@ jobs:
         branch: auto-updates/update-actions-${{ steps.inferbranch.outputs.branch }}
         signoff: true
         delete-branch: true
+
+        # What labels to add
+        labels: ${{ env.pr_labels }}
+
         # Note this is hard-coded based on the added repos in main.go
         path: main
 

--- a/.github/workflows/auto-update-community.yaml
+++ b/.github/workflows/auto-update-community.yaml
@@ -111,6 +111,10 @@ jobs:
         branch: auto-updates/update-community-${{ steps.inferbranch.outputs.branch }}
         signoff: true
         delete-branch: true
+
+        # What labels to add
+        labels: ${{ env.pr_labels }}
+
         # Note this is hard-coded based on the added repos in main.go
         path: main
 

--- a/.github/workflows/auto-update-deps.yaml
+++ b/.github/workflows/auto-update-deps.yaml
@@ -119,6 +119,10 @@ jobs:
         branch: auto-updates/update-deps-${{ steps.inferbranch.outputs.branch }}
         signoff: true
         delete-branch: true
+
+        # What labels to add
+        labels: ${{ env.pr_labels }}
+
         # Note this is hard-coded based on the added repos in main.go
         path: main
 

--- a/.github/workflows/auto-update-gofmt.yaml
+++ b/.github/workflows/auto-update-gofmt.yaml
@@ -105,6 +105,10 @@ jobs:
         branch: auto-updates/update-gofmt-${{ steps.inferbranch.outputs.branch }}
         signoff: true
         delete-branch: true
+
+        # What labels to add
+        labels: ${{ env.pr_labels }}
+
         # Note this is hard-coded based on the added repos in main.go
         path: main
 

--- a/.github/workflows/auto-update-markdown.yaml
+++ b/.github/workflows/auto-update-markdown.yaml
@@ -105,6 +105,10 @@ jobs:
         branch: auto-updates/update-markdown-${{ steps.inferbranch.outputs.branch }}
         signoff: true
         delete-branch: true
+
+        # What labels to add
+        labels: ${{ env.pr_labels }}
+
         # Note this is hard-coded based on the added repos in main.go
         path: main
 

--- a/.github/workflows/auto-update-misspell.yaml
+++ b/.github/workflows/auto-update-misspell.yaml
@@ -105,6 +105,10 @@ jobs:
         branch: auto-updates/update-misspell-${{ steps.inferbranch.outputs.branch }}
         signoff: true
         delete-branch: true
+
+        # What labels to add
+        labels: ${{ env.pr_labels }}
+
         # Note this is hard-coded based on the added repos in main.go
         path: main
 

--- a/actions/update-actions/action.yaml
+++ b/actions/update-actions/action.yaml
@@ -23,8 +23,6 @@ inputs:
   repo:
     description: 'The repo being copied to, for repo-specific customizations.'
 outputs:
-  create_pr:
-    description: "Whether a PR should be created because there were meaningful changes"
   log:
     description: "Log of changes"
 runs:

--- a/actions/update-actions/entrypoint.sh
+++ b/actions/update-actions/entrypoint.sh
@@ -36,6 +36,5 @@ create_pr="true"
 chown -R --reference=. .
 
 echo "create_pr=${create_pr}" >> $GITHUB_ENV
-echo "::set-output name=create_pr::${create_pr}"
 
 echo "::set-output name=log::$log"

--- a/actions/update-community/action.yaml
+++ b/actions/update-community/action.yaml
@@ -21,8 +21,6 @@ inputs:
   organization:
     decription: "The organization that the target repo belongs to"
 outputs:
-  create_pr:
-    description: "Whether a PR should be created because there were meaningful changes"
   log:
     description: "Log of changes"
 runs:

--- a/actions/update-community/entrypoint.sh
+++ b/actions/update-community/entrypoint.sh
@@ -38,6 +38,5 @@ fi
 chown -R --reference=. .
 
 echo "create_pr=${create_pr}" >> $GITHUB_ENV
-echo "::set-output name=create_pr::${create_pr}"
 
 echo "::set-output name=log::${log}"

--- a/actions/update-community/entrypoint.sh
+++ b/actions/update-community/entrypoint.sh
@@ -18,6 +18,10 @@ set -e
 
 log=""
 create_pr="false"
+# The label used for Prow Tide to auto-merge PRs that pass all the required presubmit checks.
+# Must be configured in Prow to be effective. Example:
+# https://github.com/knative/test-infra/blob/66d6a1f645ff585bfd1bce0eee0cb3446c7405b9/prow/config.yaml#L168
+pr_labels="skip-review"
 
 FILE="OWNERS_ALIASES"
 if [ "${ORGANIZATION}" != "knative" ] ; then
@@ -38,5 +42,6 @@ fi
 chown -R --reference=. .
 
 echo "create_pr=${create_pr}" >> $GITHUB_ENV
+echo "pr_labels=${pr_labels}" >> $GITHUB_ENV
 
 echo "::set-output name=log::${log}"

--- a/actions/update-deps/action.yaml
+++ b/actions/update-deps/action.yaml
@@ -25,8 +25,6 @@ inputs:
   pr-empty-deps:
     description: "If true, send update PRs even for deps changes that don't change vendor. Defaults to false to reduce no-op PR spam."
 outputs:
-  create_pr:
-    description: "Whether a PR should be created because there were meaningful changes"
   log:
     description: "Report on module changes"
 runs:

--- a/actions/update-deps/entrypoint.sh
+++ b/actions/update-deps/entrypoint.sh
@@ -74,6 +74,5 @@ done
 chown -R --reference=. .
 
 echo "create_pr=${create_pr}" >> $GITHUB_ENV
-echo "::set-output name=create_pr::${create_pr}"
 
 echo "::set-output name=log::$deplog"

--- a/actions/update-gofmt/action.yaml
+++ b/actions/update-gofmt/action.yaml
@@ -18,8 +18,6 @@ branding:
   icon: smile
   color: green
 outputs:
-  create_pr:
-    description: "Whether a PR should be created because there were meaningful changes"
   log:
     description: "Report on module changes"
 runs:

--- a/actions/update-gofmt/entrypoint.sh
+++ b/actions/update-gofmt/entrypoint.sh
@@ -43,6 +43,5 @@ fi
 chown -R --reference=. .
 
 echo "create_pr=${create_pr}" >> $GITHUB_ENV
-echo "::set-output name=create_pr::${create_pr}"
 
 echo "::set-output name=log::$log"

--- a/actions/update-markdown/action.yaml
+++ b/actions/update-markdown/action.yaml
@@ -18,8 +18,6 @@ branding:
   icon: star
   color: blue
 outputs:
-  create_pr:
-    description: "Whether a PR should be created because there were meaningful changes"
   log:
     description: "Log of changes"
 runs:

--- a/actions/update-markdown/entrypoint.sh
+++ b/actions/update-markdown/entrypoint.sh
@@ -24,6 +24,6 @@ log=$(prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor 
 # See https://github.com/knative-sandbox/knobots/issues/79
 chown -R --reference=. .
 
-echo "::set-output name=create_pr::true"
+echo "create_pr=${create_pr}" >> $GITHUB_ENV
 
 echo "::set-output name=log::${log}"

--- a/actions/update-misspell/action.yaml
+++ b/actions/update-misspell/action.yaml
@@ -18,8 +18,6 @@ branding:
   icon: pen-tool
   color: green
 outputs:
-  create_pr:
-    description: "Whether a PR should be created because there were meaningful changes"
   log:
     description: "Report on spelling changes"
 runs:

--- a/actions/update-misspell/entrypoint.sh
+++ b/actions/update-misspell/entrypoint.sh
@@ -35,6 +35,5 @@ fi
 chown -R --reference=. .
 
 echo "create_pr=${create_pr}" >> $GITHUB_ENV
-echo "::set-output name=create_pr::${create_pr}"
 
 echo "::set-output name=log::$log"

--- a/cmd/gen-actions/actions_template.yaml
+++ b/cmd/gen-actions/actions_template.yaml
@@ -107,6 +107,10 @@ jobs:
         branch: auto-updates/{{.Action}}-{{github "steps.inferbranch.outputs.branch"}}
         signoff: true
         delete-branch: true
+
+        # What labels to add
+        labels: {{github "env.pr_labels"}}
+
         # Note this is hard-coded based on the added repos in main.go
         path: main
 


### PR DESCRIPTION
1. Remove `create_pr` from outputs since all the actions are already using it as an env var. This move is already reflected in the [README](https://github.com/knative-sandbox/knobots/blob/main/README.md) so it looks it just needs some cleanups.

2. Add `skip-review` label to enable auto-merge PRs that update community files. This is part of the work for https://github.com/knative/test-infra/issues/2965. In the future the same config can be extended to other actions as well.