### PR TITLE
OWNER_ALIASES in knative/community are in a different location now

### DIFF
--- a/actions/update-community/action.yaml
+++ b/actions/update-community/action.yaml
@@ -19,7 +19,7 @@ branding:
   color: green
 inputs:
   organization:
-    decription: "The organization that the target repo belongs to"
+    description: "The organization that the target repo belongs to"
 outputs:
   log:
     description: "Log of changes"

--- a/actions/update-community/entrypoint.sh
+++ b/actions/update-community/entrypoint.sh
@@ -23,10 +23,7 @@ create_pr="false"
 # https://github.com/knative/test-infra/blob/66d6a1f645ff585bfd1bce0eee0cb3446c7405b9/prow/config.yaml#L168
 pr_labels="skip-review"
 
-FILE="OWNERS_ALIASES"
-if [ "${ORGANIZATION}" != "knative" ] ; then
-  FILE="${ORGANIZATION}-OWNERS_ALIASES"
-fi
+FILE="peribolos/${ORGANIZATION}-OWNERS_ALIASES"
 
 if [ -f "${GITHUB_WORKSPACE}/meta/${FILE}" ]; then
   cp "${GITHUB_WORKSPACE}/meta/${FILE}" "${GITHUB_WORKSPACE}/main/OWNERS_ALIASES"


### PR DESCRIPTION
See: https://github.com/knative/community/pull/1008

The move was necessary so TOC can approve peribolos updates