### PR TITLE
default inputs on scheduled runs

### DIFF
--- a/workflow-templates/knative-releasability.yaml
+++ b/workflow-templates/knative-releasability.yaml
@@ -14,22 +14,19 @@ on:
       releaseFamily:
         description: 'Release? (vX.Y)'
         required: false
-        default: 'v1.4'
       moduleReleaseFamily:
         description: 'Module Release? (vX.Y)'
         required: false
-        default: 'v0.31'
       slackChannel:
         description: 'Slack Channel? (release-#)'
         required: false
-        default: 'release-1dot4'
 
 jobs:
   releasability:
     uses: knative/actions/.github/workflows/releasability.yaml@main
     with:
-      releaseFamily: ${{ github.event.inputs.releaseFamily }}
-      moduleReleaseFamily: ${{ github.event.inputs.moduleReleaseFamily }}
-      slackChannel: ${{ github.event.inputs.slackChannel }}
+      releaseFamily: ${{ github.event.inputs.releaseFamily || 'v1.4' }}
+      moduleReleaseFamily: ${{ github.event.inputs.moduleReleaseFamily || 'v0.31' }}
+      slackChannel: ${{ github.event.inputs.slackChannel || 'release-1dot4' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
They were blank otherwise