### PR TITLE
Run knative-go-test action on main branch

### DIFF
--- a/workflow-templates/knative-go-test.yaml
+++ b/workflow-templates/knative-go-test.yaml
@@ -6,6 +6,9 @@
 name: Test
 
 on:
+  push:
+    branches: [ 'main', 'release-*' ]
+
   pull_request:
     branches: [ 'main', 'release-*' ]
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

This PR brings back the former behavior, when unit tests and Codecov is executed on push to main and release branches.

https://knative.slack.com/archives/CCSNR4FCH/p1649768685403129

- Run knative-go-test action on main branch

/cc @dprotaso 