### PR TITLE
update-actions-skip-review

### DIFF
--- a/actions/update-actions/entrypoint.sh
+++ b/actions/update-actions/entrypoint.sh
@@ -40,5 +40,6 @@ pr_labels="skip-review"
 chown -R --reference=. .
 
 echo "create_pr=${create_pr}" >> $GITHUB_ENV
+echo "pr_labels=${pr_labels}" >> $GITHUB_ENV
 
 echo "::set-output name=log::$log"

--- a/actions/update-actions/entrypoint.sh
+++ b/actions/update-actions/entrypoint.sh
@@ -31,6 +31,10 @@ yaml2json < "${GITHUB_WORKSPACE}/config/actions-omitted.yaml" |
 
 create_pr="true"
 
+# Must be configured in Prow to be effective. Example:
+# https://github.com/knative/test-infra/blob/66d6a1f645ff585bfd1bce0eee0cb3446c7405b9/prow/config.yaml#L168
+pr_labels="skip-review"
+
 # Ensure files have the same owner as the checkout directory.
 # See https://github.com/knative-sandbox/knobots/issues/79
 chown -R --reference=. .


### PR DESCRIPTION
Updating actions should skip review as the templates are approved in this repo