### PR TITLE
Bump update-deps to next release version

### DIFF
--- a/actions/update-deps/action.yaml
+++ b/actions/update-deps/action.yaml
@@ -35,6 +35,6 @@ runs:
     # CHANGE THIS LINE AFTER RELEASE
     # This should point to the _upcoming_ release
     # *******************************************
-    RELEASE: ${{ inputs.release || 'v1.5' }}
-    MODULE_RELEASE: ${{ inputs.module-release || 'v0.32' }}
+    RELEASE: ${{ inputs.release || 'v1.6' }}
+    MODULE_RELEASE: ${{ inputs.module-release || 'v0.33' }}
     FORCE_DEPS: ${{ inputs.pr-empty-deps }}


### PR DESCRIPTION
# Changes

Auto-update haven't floated Knative deps after 1.5 due to missing version bump.

In addition should fix: 
https://github.com/knative-sandbox/knobots/runs/6804629743?check_suite_focus=true
<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom:  Bump update-deps to next release version


/cc @dprotaso @evankanderson 