### PR TITLE
Stop assigning community updates PRs to people

### DIFF
--- a/.github/workflows/auto-update-community.yaml
+++ b/.github/workflows/auto-update-community.yaml
@@ -127,9 +127,6 @@ jobs:
         body: |
           ${{ github.event.inputs.reason || 'Cron' }} -${{ github.actor }}
 
-          /cc ${{ matrix.assignees }}
-          /assign ${{ matrix.assignees }}
-
           Produced by: ${{ github.repository }}/actions/update-community
 
           Details:

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,3 +1,0 @@
-## Knative Community Code of Conduct
-
-The [Knative Community Code of Conduct](https://github.com/knative/community/blob/main/CODE-OF-CONDUCT.md) is defined in the [Knative community repository](https://github.com/knative/community).

--- a/repos.yaml
+++ b/repos.yaml
@@ -218,7 +218,7 @@
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/kperf'
   channel: 'performance'
-  assignees: knative-sandbox/productivity-wg-leads
+  assignees: knative-sandbox/kperf-approvers
 
 # knative-sandbox/kn-plugin-*, sorted alphabetically
 - name: 'knative-sandbox/homebrew-kn-plugins'


### PR DESCRIPTION
This PR does the following:
- Removes CoC file so github can show the CoC file in knative-sandbox/.github
- Send kperf knobots changes to kperf-approvers. Productivity can't approve changes in that repo
- Stops cc and assign for PRs that are automatically merged(PRs with skip-review label).