### PR TITLE
Remove releasability action from some repos

### DIFF
--- a/actions-omitted.yaml
+++ b/actions-omitted.yaml
@@ -38,3 +38,6 @@ knative-sandbox/discovery:
 knative-sandbox/kn-plugin-migration:
   omit:
     - knative-releasability
+knative-sandbox/container-freezer:
+  omit:
+    - knative-releasability

--- a/actions-omitted.yaml
+++ b/actions-omitted.yaml
@@ -1,10 +1,5 @@
 # Avoid syncing certain actions to certain repos. (For example, go testing from non-go repos.)
 # This uses a glob prefix match (adds * to the end of each omit), so no need to specify '.yaml'
-knative/website:
-  omit:
-    - knative-go-
-    - knative-releasability
-    - knative-release-notes
 knative/test-infra:
   omit:
     - knative-releasability

--- a/actions-omitted.yaml
+++ b/actions-omitted.yaml
@@ -1,5 +1,16 @@
 # Avoid syncing certain actions to certain repos. (For example, go testing from non-go repos.)
 # This uses a glob prefix match (adds * to the end of each omit), so no need to specify '.yaml'
+knative/website:
+  omit:
+    - knative-go-
+    - knative-releasability
+    - knative-release-notes
+knative/test-infra:
+  omit:
+    - knative-releasability
+knative/client-pkg:
+  omit:
+    - knative-releasability
 knative-sandbox/kn-plugin-diag:
   omit:
     - knative-releasability
@@ -9,8 +20,21 @@ knative-sandbox/kn-plugin-sample:
 knative-sandbox/kperf:
   omit:
     - knative-releasability
-knative/website:
+knative-sandbox/eventing-natss:
   omit:
-    - knative-go-
     - knative-releasability
-    - knative-release-notes
+knative-sandbox/kn-plugin-func:
+  omit:
+    - knative-releasability
+knative-sandbox/kn-plugin-service-log:
+  omit:
+    - knative-releasability
+knative-sandbox/eventing-couchdb:
+  omit:
+    - knative-releasability
+knative-sandbox/discovery:
+  omit:
+    - knative-releasability
+knative-sandbox/kn-plugin-migration:
+  omit:
+    - knative-releasability


### PR DESCRIPTION
The repos that I have marked for omission are not part of the current release train: https://github.com/knative/release/issues/141 and https://github.com/knative/release/blob/main/.github/ISSUE_TEMPLATE/release-checklist.yaml

This has the unintended effect of making the release-1dotX very noisy which isn't helpful.

@knative-sandbox/knative-release-leads 
/cc @evankanderson 

```
 REDACTED  MCW0CDP3YY  ~  Desktop  Git  $  gh api repos/knative/serving/releases | jq '.[0] | .name,.created_at' | tr '\n' ' ' && echo
"Knative Serving release v1.6.0" "2022-07-12T20:28:39Z"
 REDACTED  MCW0CDP3YY  ~  Desktop  Git  $  gh api repos/knative/test-infra/releases | jq '.[0] | .name,.created_at' | tr '\n' ' ' && echo
null null
 REDACTED  MCW0CDP3YY  ~  Desktop  Git  $  gh api repos/knative/client-pkg/releases | jq '.[0] | .name,.created_at' | tr '\n' ' ' && echo
null null
 REDACTED  MCW0CDP3YY  ~  Desktop  Git  $  gh api repos/knative-sandbox/eventing-natss/releases | jq '.[0] | .name,.created_at' | tr '\n' ' ' && echo
"Knative Eventing Natss release v1.4.0" "2022-04-19T21:26:58Z"
 REDACTED  MCW0CDP3YY  ~  Desktop  Git  $  gh api repos/knative-sandbox/kn-plugin-func/releases | jq '.[0] | .name,.created_at' | tr '\n' ' ' && echo
"Knative Kn Plugin Func release v0.25.1" "2022-07-29T11:11:44Z"
 REDACTED  MCW0CDP3YY  ~  Desktop  Git  $  gh api repos/knative-sandbox/kn-plugin-service-log/releases | jq '.[0] | .name,.created_at' | tr '\n' ' ' && echo
"Knative Kn Plugin Service Log release v1.1.0" "2022-04-13T18:24:09Z"
 REDACTED  MCW0CDP3YY  ~  Desktop  Git  $  gh api repos/knative-sandbox/eventing-couchdb/releases | jq '.[0] | .name,.created_at' | tr '\n' ' ' && echo
"Knative Eventing Couchdb release v1.1.0" "2021-12-14T13:02:11Z"
 REDACTED  MCW0CDP3YY  ~  Desktop  Git  $  gh api repos/knative-sandbox/discovery/releases | jq '.[0] | .name,.created_at' | tr '\n' ' ' && echo
"Knative Discovery release v0.26.0" "2021-09-22T08:56:43Z"
 REDACTED  MCW0CDP3YY  ~  Desktop  Git  $  gh api repos/knative-sandbox/kn-plugin-migration/releases | jq '.[0] | .name,.created_at' | tr '\n' ' ' && echo
null null
 REDACTED  MCW0CDP3YY  ~  Desktop  Git  $  gh api repos/knative-sandbox/container-freezer/releases | jq '.[0] | .name,.created_at' | tr '\n' ' ' && echo
"Knative Container Freezer release v0.1.0" "2022-07-12T00:23:28Z"
```