### PR TITLE
chore: knative-sandbox/func-tastic in repos.yaml

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -250,12 +250,6 @@
   channel: 'cli'
   assignees: 'knative-sandbox/client-writers'
 
-- name: 'knative-sandbox/kn-plugin-func'
-  meta-organization: 'knative-sandbox'
-  fork: 'knative-automation/kn-plugin-func'
-  channel: 'functions-sandbox'
-  assignees: 'knative-sandbox/kn-plugin-func-approvers'
-
 - name: 'knative-sandbox/kn-plugin-migration'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/kn-plugin-migration'
@@ -311,3 +305,17 @@
   fork: 'knative-automation/sources-for-knative'
   channel: 'vmware-sources'
   assignees: we don't use Prow
+
+# knative-sandbox (functions)
+- name: 'knative-sandbox/kn-plugin-func'
+  meta-organization: 'knative-sandbox'
+  fork: 'knative-automation/kn-plugin-func'
+  channel: 'functions-sandbox'
+  assignees: 'knative-sandbox/kn-plugin-func-approvers'
+
+- name: 'knative-sandbox/func-tastic'
+  meta-organization: 'knative-sandbox'
+  fork: 'knative-automation/func-tastic'
+  channel: 'functions-sandbox'
+  assignees: 'knative-sandbox/func-tastic-approvers'
+


### PR DESCRIPTION
# Changes

Also moves the kn-plugin-func repo to the newly added functions section to keep the two function related repos together.

Signed-off-by: Lance Ball <lball@redhat.com>

