### PR TITLE
chore: remove func-tastic from knative GH actions

### DIFF
--- a/actions-exclude.yaml
+++ b/actions-exclude.yaml
@@ -6,3 +6,4 @@
 - "knative/actions"
 - "knative/infra"
 - "knative-sandbox/knobots"
+- "knative-sandbox/func-tastic"


### PR DESCRIPTION
Some of the actions are OK, but others such as `go test` are causing
pull requests to fail. This repo is not a typical golang repo in the
traditional knative sense. It is a set of templates for the `func`
binary and as such does not need most of the regular workflow jobs.

Signed-off-by: Lance Ball <lball@redhat.com>

