### PR TITLE
Fix `gh` cli gpg key

### DIFF
--- a/.github/workflows/auto-fork.yaml
+++ b/.github/workflows/auto-fork.yaml
@@ -47,10 +47,11 @@ jobs:
 
     - name: Install gh
       run: |
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-        sudo apt-add-repository https://cli.github.com/packages
-        sudo apt update
-        sudo apt install gh
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+        sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+        sudo apt-get update
+        sudo apt-get install gh -qqy
 
     - name: Check out code onto GOPATH
       uses: actions/checkout@v2


### PR DESCRIPTION
`gh` cli GPG key was rotated in https://github.com/cli/cli/issues/617 as it expired. The new method should be more robust.