### PR TITLE
chore: add kn-plugin-func to release train

### DIFF
--- a/actions-omitted.yaml
+++ b/actions-omitted.yaml
@@ -18,9 +18,6 @@ knative-sandbox/kperf:
 knative-sandbox/eventing-natss:
   omit:
     - knative-releasability
-knative-sandbox/kn-plugin-func:
-  omit:
-    - knative-releasability
 knative-sandbox/kn-plugin-service-log:
   omit:
     - knative-releasability

--- a/deps-exclude.yaml
+++ b/deps-exclude.yaml
@@ -1,7 +1,6 @@
 - "knative/release"
 - "knative/homebrew-client"
 - "knative-sandbox/homebrew-kn-plugins"
-- "knative-sandbox/kn-plugin-func"
 - "knative-sandbox/.github"
 - "knative/hack"
 - "knative/actions"

--- a/repos.yaml
+++ b/repos.yaml
@@ -312,12 +312,12 @@
 - name: 'knative-sandbox/kn-plugin-func'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/kn-plugin-func'
-  channel: 'functions-sandbox'
+  channel: 'functions'
   assignees: 'knative-sandbox/kn-plugin-func-approvers'
 
 - name: 'knative-sandbox/func-tastic'
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/func-tastic'
-  channel: 'functions-sandbox'
+  channel: 'functions'
   assignees: 'knative-sandbox/func-tastic-approvers'
 


### PR DESCRIPTION
This commit removes the `releasability` workflow exception for kn-plugin-func, and no longer excludes it from the deps workflow.

Incidentally, the Slack channel recently changed, so I have also fixed that reference here.

This is all in preparation for functions to ride the knative release train.

/kind chore

Signed-off-by: Lance Ball <lball@redhat.com>

