### PR TITLE
Drop detail log in PR body

### DIFF
--- a/.github/workflows/auto-update-deps.yaml
+++ b/.github/workflows/auto-update-deps.yaml
@@ -140,11 +140,6 @@ jobs:
 
           Produced by: ${{ github.repository }}/actions/update-deps
 
-          Details:
-          ```
-          ${{ steps.work.outputs.log }}
-          ```
-
     - name: Report error
       uses: rtCamp/action-slack-notify@v2
       if: ${{ failure() }}


### PR DESCRIPTION
Currently `Update Deps and Codegen` is failing as: https://github.com/knative-sandbox/knobots/actions/workflows/auto-update-deps.yaml

This is due to the error `##[error]Validation Failed: {"resource":"Issue","code":"custom","field":"body","message":"body is too long (maximum is 65536 characters)"}` in [log](https://pipelines.actions.githubusercontent.com/serviceHosts/02472a65-baf5-4806-be79-3bf6384a6957/_apis/pipelines/1/runs/6445/signedlogcontent/21?urlExpires=2022-10-12T02%3A04%3A58.7482262Z&urlSigningMethod=HMACV1&urlSignature=enXamonNdb%2FBrwb3UB2k%2FUYPioLwVw6jSaekUa4gsTk%3D).

The body contains the following line and it exceeds the limit.

```
bumping golang.org/x/mod 9b9b3d8...86c51ed:
  > 86c51ed all: remove golang.org/x/xerrors dependency
  > 41445a1 zip: update TestUnzipSizeLimitsSpecial for CL 366854
  > 145421b all: gofmt
  > 605edab sumdb/note: relax prescriptiveness of key hash format
  > a410e2d sumdb/note: catch a Verifiers that returns the wrong Verifier
  ... continue many commits ...
```

/cc @lionelvillard @kvmware @dprotaso @evankanderson 
