### PR TITLE
Run of `go run ./cmd/gen-actions`

### DIFF
--- a/.github/workflows/auto-update-deps.yaml
+++ b/.github/workflows/auto-update-deps.yaml
@@ -140,6 +140,11 @@ jobs:
 
           Produced by: ${{ github.repository }}/actions/update-deps
 
+          Details:
+          ```
+          ${{ steps.work.outputs.log }}
+          ```
+
     - name: Report error
       uses: rtCamp/action-slack-notify@v2
       if: ${{ failure() }}


### PR DESCRIPTION
The `go run ./cmd/gen-actions` has not seemed to be ran in a bit.

EDIT: omitting auto-update-community.yaml changes