### PR TITLE
Fix unsafe git dir error

### DIFF
--- a/actions/update-deps/entrypoint.sh
+++ b/actions/update-deps/entrypoint.sh
@@ -18,14 +18,6 @@ set -e
 
 deplog=""
 
-# Ensure files have the same owner as the checkout directory.
-# See https://github.com/knative-sandbox/knobots/issues/79
-chown -R --reference=. main
-# This has been moved here because the scripts below use `git`
-# and the parent directory does not match the docker user and
-# thus gives an error. For more info see:
-# https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
-
 cd main
 
 # Determine the name of the go module.
@@ -76,6 +68,10 @@ for x in $(git diff-index --name-only HEAD --); do
     create_pr="true"
     break
 done
+
+# Ensure files have the same owner as the checkout directory.
+# See https://github.com/knative-sandbox/knobots/issues/79
+chown -R --reference=. .
 
 echo "create_pr=${create_pr}" >> $GITHUB_ENV
 

--- a/actions/update-deps/entrypoint.sh
+++ b/actions/update-deps/entrypoint.sh
@@ -18,6 +18,12 @@ set -e
 
 deplog=""
 
+# The scripts below use `git` on the checked out .../main that has a
+# different user than the docker user which gives an error. We thus have
+# to explicitly allow it with the below command. For more info see:
+# https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
+git config --global --add safe.directory /github/workspace/main
+
 cd main
 
 # Determine the name of the go module.


### PR DESCRIPTION
While https://github.com/knative-sandbox/knobots/commit/e19afa3be6e4b46b882b49b3503fc96a71179709 fixes the issue when running the docker image locally, GHAs still fails with the same issue. The included changes were testes using GHAs and passed. I also reverted the previous changes as that did not solve the issue.

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Fix https://github.com/knative/test-infra/issues/3707

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/knative/test-infra/issues/3707

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
