### PR TITLE
drop external orgs

### DIFF
--- a/community-exclude.yaml
+++ b/community-exclude.yaml
@@ -1,4 +1,1 @@
-# Outside Knative
-# May be able to cover with "google"
-- "google"
-- "vmware-tanzu"
+[]

--- a/repos.yaml
+++ b/repos.yaml
@@ -304,14 +304,7 @@
   meta-organization: 'knative-sandbox'
   fork: 'knative-automation/scaling-group'
   channel: 'serving'
-  assignees: knative-sandbox/serving-wg-leads 
-
-# vmware-tanzu
-- name: 'vmware-tanzu/sources-for-knative'
-  meta-organization: 'knative' # Pull actions from the Knative org.
-  fork: 'knative-automation/sources-for-knative'
-  channel: 'vmware-sources'
-  assignees: we don't use Prow
+  assignees: knative-sandbox/serving-wg-leads
 
 # knative-sandbox (async-component)
 


### PR DESCRIPTION
We created knobots when actions was pretty immature - now it's pretty good and  downstream orgs can setup their own workflows and potentially use stuff from `knative/actions`