### PR TITLE
Add Git submodules to safe directories

### DIFF
--- a/actions/update-deps/entrypoint.sh
+++ b/actions/update-deps/entrypoint.sh
@@ -26,6 +26,9 @@ git config --global --add safe.directory /github/workspace/main
 
 cd main
 
+# Additionally add Git submodules to the safe directory config
+git config --file .gitmodules --get-regexp path | awk '{ print $2 }' | xargs -I{} git config --global --add safe.directory {}
+
 # Determine the name of the go module.
 if [[ -f go.mod ]]; then
     export MODULE_NAME=$(go mod graph | cut -d' ' -f 1 | grep -v '@' | head -1)


### PR DESCRIPTION
In eventing-istio we use Git submodules to hold
run eventing core tests and auto update deps
failed in https://github.com/knative-sandbox/knobots/actions/runs/4339031748/jobs/7576246142
with: `fatal: detected dubious ownership in repository at`

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add Git submodules to safe directories similarly to /github/workspace/main