### PR TITLE
[WIP]: Switch to `GITHUB_OUTPUT` env var instead of using deprecated `set-output`

### DIFF
--- a/.github/workflows/auto-update-actions.yaml
+++ b/.github/workflows/auto-update-actions.yaml
@@ -86,7 +86,7 @@ jobs:
       id: inferbranch
       run: |
         cd main
-        echo "::set-output name=branch::$(git branch --show-current)"
+        echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
 
     - name: Apply work
       id: work

--- a/.github/workflows/auto-update-community.yaml
+++ b/.github/workflows/auto-update-community.yaml
@@ -86,7 +86,7 @@ jobs:
       id: inferbranch
       run: |
         cd main
-        echo "::set-output name=branch::$(git branch --show-current)"
+        echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
 
     - name: Apply work
       id: work

--- a/.github/workflows/auto-update-deps.yaml
+++ b/.github/workflows/auto-update-deps.yaml
@@ -90,7 +90,7 @@ jobs:
       id: inferbranch
       run: |
         cd main
-        echo "::set-output name=branch::$(git branch --show-current)"
+        echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
 
     - name: Apply work
       id: work

--- a/.github/workflows/auto-update-gofmt.yaml
+++ b/.github/workflows/auto-update-gofmt.yaml
@@ -80,7 +80,7 @@ jobs:
       id: inferbranch
       run: |
         cd main
-        echo "::set-output name=branch::$(git branch --show-current)"
+        echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
 
     - name: Apply work
       id: work

--- a/.github/workflows/auto-update-markdown.yaml
+++ b/.github/workflows/auto-update-markdown.yaml
@@ -80,7 +80,7 @@ jobs:
       id: inferbranch
       run: |
         cd main
-        echo "::set-output name=branch::$(git branch --show-current)"
+        echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
 
     - name: Apply work
       id: work

--- a/.github/workflows/auto-update-misspell.yaml
+++ b/.github/workflows/auto-update-misspell.yaml
@@ -80,7 +80,7 @@ jobs:
       id: inferbranch
       run: |
         cd main
-        echo "::set-output name=branch::$(git branch --show-current)"
+        echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
 
     - name: Apply work
       id: work

--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -177,7 +177,7 @@ jobs:
         deplog=$(modlog -s ${{ matrix.module }} $from_sha $to_sha || true)
         deplog="${deplog//$'\n'/'%0A'}"
         deplog="${deplog//$'\r'/'%0D'}"
-        echo "::set-output name=deplog::$deplog"
+        echo "deplog=$deplog" >> $GITHUB_OUTPUT
 
 
     - name: Create Pull Request

--- a/actions/calculate-matrix/entrypoint.sh
+++ b/actions/calculate-matrix/entrypoint.sh
@@ -47,5 +47,5 @@ echo "::group::Matrix includes for ${NAME}"
 echo "${SELECTED_REPOS}" | jq .
 echo "::endgroup::"
 
-echo "::set-output name=includes::${SELECTED_REPOS}"
-echo "::set-output name=names::${SELECTED_NAMES}"
+echo "includes=${SELECTED_REPOS}" >> $GITHUB_OUTPUT
+echo "names=${SELECTED_NAMES}" >> $GITHUB_OUTPUT

--- a/actions/update-actions/entrypoint.sh
+++ b/actions/update-actions/entrypoint.sh
@@ -42,4 +42,4 @@ chown -R --reference=. .
 echo "create_pr=${create_pr}" >> $GITHUB_ENV
 echo "pr_labels=${pr_labels}" >> $GITHUB_ENV
 
-echo "::set-output name=log::$log"
+echo "log=$log" >> $GITHUB_OUTPUT

--- a/actions/update-community/entrypoint.sh
+++ b/actions/update-community/entrypoint.sh
@@ -41,4 +41,4 @@ chown -R --reference=. .
 echo "create_pr=${create_pr}" >> $GITHUB_ENV
 echo "pr_labels=${pr_labels}" >> $GITHUB_ENV
 
-echo "::set-output name=log::${log}"
+echo "log=${log}" >> $GITHUB_OUTPUT

--- a/actions/update-deps/entrypoint.sh
+++ b/actions/update-deps/entrypoint.sh
@@ -47,7 +47,7 @@ if [[ -f go.mod ]]; then
       releaseFlags+=("--release ${RELEASE} --module-release ${MODULE_RELEASE}")
     fi
 
-    echo "::set-output name=update-dep-cmd::./hack/update-deps.sh --upgrade ${releaseFlags[@]}"
+    echo "update-dep-cmd=./hack/update-deps.sh --upgrade ${releaseFlags[@]}" >> $GITHUB_OUTPUT
     ./hack/update-deps.sh --upgrade ${releaseFlags[@]}
     # capture logs for the module changes
     deplog=$(modlog . HEAD dirty || true)
@@ -84,4 +84,4 @@ chown -R --reference=. .
 
 echo "create_pr=${create_pr}" >> $GITHUB_ENV
 
-echo "::set-output name=log::$deplog"
+echo "log=$deplog" >> $GITHUB_OUTPUT

--- a/actions/update-gofmt/entrypoint.sh
+++ b/actions/update-gofmt/entrypoint.sh
@@ -44,4 +44,4 @@ chown -R --reference=. .
 
 echo "create_pr=${create_pr}" >> $GITHUB_ENV
 
-echo "::set-output name=log::$log"
+echo "log=$log" >> $GITHUB_OUTPUT

--- a/actions/update-markdown/entrypoint.sh
+++ b/actions/update-markdown/entrypoint.sh
@@ -34,4 +34,4 @@ chown -R --reference=. .
 
 echo "create_pr=${create_pr}" >> $GITHUB_ENV
 
-echo "::set-output name=log::${log}"
+echo "log=${log}" >> $GITHUB_OUTPUT

--- a/actions/update-misspell/entrypoint.sh
+++ b/actions/update-misspell/entrypoint.sh
@@ -36,4 +36,4 @@ chown -R --reference=. .
 
 echo "create_pr=${create_pr}" >> $GITHUB_ENV
 
-echo "::set-output name=log::$log"
+echo "log=$log" >> $GITHUB_OUTPUT

--- a/cmd/gen-actions/actions_template.yaml
+++ b/cmd/gen-actions/actions_template.yaml
@@ -80,7 +80,7 @@ jobs:
       id: inferbranch
       run: |
         cd main
-        echo "::set-output name=branch::$(git branch --show-current)"
+        echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
 
     - name: Apply work
       id: work


### PR DESCRIPTION
On some actions (e.g. [run 4374781596](https://github.com/knative-sandbox/knobots/actions/runs/4374781596)), we see the following notice: 
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
This PR addresses it and uses env vars instead.


# Changes

- :broom: set-output was deprecated and `GITHUB_OUTPUT` env var should be used instead according to
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.

/kind cleanup

WIP: as I am not sure how to test it 