### PR TITLE
:broom: Extract tools to knative.dev/toolbox

### DIFF
--- a/.github/workflows/auto-fork.yaml
+++ b/.github/workflows/auto-fork.yaml
@@ -43,7 +43,7 @@ jobs:
         go-version: 1.19.x
 
     - name: Install Dependencies
-      run: go install knative.dev/test-infra/buoy@main
+      run: go install knative.dev/toolbox/buoy@main
 
     - name: Install gh
       run: |

--- a/actions/update-deps/Dockerfile
+++ b/actions/update-deps/Dockerfile
@@ -18,7 +18,7 @@ FROM golang:1.19
 RUN go install github.com/google/ko@latest
 RUN go install github.com/google/go-licenses@latest
 RUN go install github.com/dprotaso/modlog@latest
-RUN go install knative.dev/test-infra/buoy@latest
+RUN go install knative.dev/toolbox/buoy@latest
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
# Changes

- :broom: Use extracted tools from knative.dev/toolbox

/kind cleanup

Related https://github.com/knative/toolbox/pull/3
Related https://github.com/knative/community/issues/1291
