### PR TITLE
Remove job to copy eventing-kafka nightlies to eventing-kafka-broker repo

### DIFF
--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -97,15 +97,6 @@ jobs:
           fork: eventing-kafka-broker
           channel: eventing-delivery
           assignee: "@knative/delivery-wg-leads"
-        - nightly: eventing-kafka-broker-eventing-kafka
-          module: knative.dev/eventing-kafka-broker
-          directory: ./third_party/eventing-kafka-latest
-          files: channel-crds.yaml source-crd.yaml
-          bucket: eventing-kafka
-          repository: knative-sandbox/eventing-kafka-broker
-          fork: eventing-kafka-broker
-          channel: eventing-delivery
-          assignee: "@knative/delivery-wg-leads"
         - nightly: eventing-rabbitmq-eventing
           module: knative.dev/eventing-rabbitmq
           directory: ./third_party/eventing-latest


### PR DESCRIPTION
# Changes

- :broom: Remove job to copy the nightly channel & source CRDs from eventing-kafka to the eventing-kafka-broker repo as the APIs have been migrated.

/kind cleanup
/assign @matzew @pierDipi @aliok 