### PR TITLE
Revert "force update deps during release time (#297)"

### DIFF
--- a/.github/workflows/auto-update-deps.yaml
+++ b/.github/workflows/auto-update-deps.yaml
@@ -34,7 +34,7 @@ on:
         description: "Release version? (vX.Y) defaults to current release"
       pr-empty-deps:
         description: "If true, send update PRs even for deps changes that don't change vendor. Use this only for releases."
-        default: "true"
+        default: "false"
       branch:
         description: "Branch Name? (empty for default branch of the respective repository)"
       

--- a/actions/update-deps/auto-apply.yaml
+++ b/actions/update-deps/auto-apply.yaml
@@ -20,7 +20,7 @@ inputs:
   description: "Release version? (vX.Y) defaults to current release"
 - name: pr-empty-deps
   description: "If true, send update PRs even for deps changes that don't change vendor. Use this only for releases."
-  default: "true"
+  default: "false"
 - name: branch
   description: "Branch Name? (empty for default branch of the respective repository)"
 

--- a/actions/update-deps/entrypoint.sh
+++ b/actions/update-deps/entrypoint.sh
@@ -65,7 +65,10 @@ fi
 # If we don't run this before the "git diff-index" it seems to list
 # every file that's been touched by codegen.
 git status
-create_pr="${FORCE_DEPS}"
+create_pr="false"
+if [[ "${FORCE_DEPS}" == "true" ]]; then
+  create_pr="true"
+fi
 for x in $(git diff-index --name-only HEAD --); do
     if [ "$(basename $x)" = "go.mod" ]; then
         continue


### PR DESCRIPTION
This reverts commit a1b9e6bf00de1bc4f2333128559c5b386853a4f6.

This will prevent knobots from creating PRs where the only updates are `go.mod` changes (eg. OWNER file updates)