### PR TITLE
Make go version consistent with actions

### DIFF
--- a/actions/update-gofmt/Dockerfile
+++ b/actions/update-gofmt/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # TODO: figure out how to template this.
-FROM golang:1.19
+FROM golang:1.20
 
 RUN go install golang.org/x/tools/cmd/goimports@latest
 


### PR DESCRIPTION
At some point we should just kill this