### PR TITLE
Use knative-sandbox teams for sandbox repos as assignees

### DIFF
--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -116,7 +116,7 @@ jobs:
           repository: knative-sandbox/eventing-istio
           fork: eventing-istio
           channel: eventing
-          assignee: "@knative/eventing-wg-leads"
+          assignee: "@knative-sandbox/eventing-wg-leads"
         - nightly: eventing-istio-eventing-kafka-broker
           module: knative.dev/eventing-istio
           directory: ./third_party/eventing-kafka-broker-latest
@@ -125,7 +125,7 @@ jobs:
           repository: knative-sandbox/eventing-istio
           fork: eventing-istio
           channel: eventing
-          assignee: "@knative/eventing-wg-leads"
+          assignee: "@knative-sandbox/eventing-wg-leads"
 
     steps:
     - name: Set up Go 1.20.x


### PR DESCRIPTION
We are seeing the following on some update nightlies PRs:

> @knative-automation: GitHub didn't allow me to request PR reviews from the following users: knative/eventing-wg-leads.
> 
> Note that only [knative-sandbox members](https://github.com/orgs/knative-sandbox/people) and repo collaborators can review this PR, and authors cannot review their own PRs.

For example on https://github.com/knative-sandbox/eventing-istio/pull/31#issuecomment-1598571578. 

This PR uses the knative-sandbox groups for assignees for knative-sandbox projects.