### PR TITLE
excluding vendor and third_party at all the level in multimodule setup in update-gofmt

### DIFF
--- a/actions/update-gofmt/entrypoint.sh
+++ b/actions/update-gofmt/entrypoint.sh
@@ -24,7 +24,7 @@ cd main
 if [[ ! -f go.mod ]]; then
     echo "No go mod, skipping..."
 else
-    export FILES=( $(find -path './vendor' -prune -o -path './third_party' -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print) )
+    export FILES=( $(find -path '*/vendor' -prune -o -path '*/third_party' -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print) )
     export GENFILES=( $(git ls-files | xargs git check-attr linguist-generated | grep 'true$' | cut -d: -f1) )
     for i in "${GENFILES[@]}"; do
         FILES=(${FILES[@]//*$i*})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# changes
changed finding patterns to include vendor and third_party path at all the level instead of root level to exclude these directories by update-gofmt at multimodule go setup.

/kind bug

Fixes #244 #259 

**Release Note**

```release-note
NONE
```
